### PR TITLE
Switch transcription to Groq API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pynput
 pyaudio
 wave
 playsound==1.2.2
-deepgram-sdk==2.12.0
+groq
 python-dotenv
 customtkinter
 pillow


### PR DESCRIPTION
## Summary
- replace Deepgram usage with Groq client
- update settings dialog for Groq API key
- update requirements

## Testing
- `python3 -m pip install --break-system-packages -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pynput)*
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689f46a6f67483249278d55fbadaaa9d