### PR TITLE
Remove invalid wave dependency from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pynput
 pyaudio
-wave
 playsound==1.2.2
 groq
 python-dotenv


### PR DESCRIPTION
## Summary
- drop `wave` from requirements.txt to avoid MySQL-python build error

## Testing
- `python -m venv venv && . venv/bin/activate && pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pynput due to 403 proxy block)*

------
https://chatgpt.com/codex/tasks/task_e_689f4ad817808324a196c61aaa17b930